### PR TITLE
Removed obsidian and pinewood stairs

### DIFF
--- a/extra.lua
+++ b/extra.lua
@@ -136,6 +136,7 @@ minetest.register_craft({
 minetest.register_craftitem("ethereal:charcoal_lump", {
 	description = "Lump of Charcoal",
 	inventory_image = "charcoal_lump.png",
+	groups = {coal = 1}
 })
 
 minetest.register_craft({

--- a/stairs.lua
+++ b/stairs.lua
@@ -80,13 +80,6 @@ stairs.register_stair_and_slab("willow_wood", "ethereal:willow_wood",
 	"Willow Wood Slab",
 	default.node_sound_wood_defaults())
 
-stairs.register_stair_and_slab("pine_wood", "default:pinewood",
-	{choppy=2,oddly_breakable_by_hand=1,flammable=3, not_in_craft_guide=1},
-	{"default_pinewood.png"},
-	"Pine Wood Stair",
-	"Pine Wood Slab",
-	default.node_sound_wood_defaults())
-
 stairs.register_stair_and_slab("redwood_wood", "ethereal:redwood_wood",
 	{choppy=2,oddly_breakable_by_hand=1,flammable=3, not_in_craft_guide=1},
 	{"redwood_wood.png"},
@@ -100,10 +93,3 @@ stairs.register_stair_and_slab("acacia_wood", "ethereal:acacia_wood",
 	"Acacia Wood Stair",
 	"Acacia Wood Slab",
 	default.node_sound_wood_defaults())
-
-stairs.register_stair_and_slab("obsidian_brick", "ethereal:obsidian_brick",
-	{cracky=1,level=3, not_in_craft_guide=1},
-	{"obsidian_brick.png"},
-	"Obsidian Brick Stair",
-	"Obsidian Brick Slab",
-	default.node_sound_stone_defaults())


### PR DESCRIPTION
Obsidian and pinewood stairs and slabs are now in default, this way they won't get doubled.